### PR TITLE
Updated GeoServer to 2.15.1 and GeoTools to 21.1. 

### DIFF
--- a/geomesa-gs-catalog-listener/pom.xml
+++ b/geomesa-gs-catalog-listener/pom.xml
@@ -32,11 +32,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.accumulo</groupId>
             <artifactId>accumulo-core</artifactId>
             <scope>provided</scope>

--- a/geomesa-gs-styling/pom.xml
+++ b/geomesa-gs-styling/pom.xml
@@ -21,10 +21,6 @@
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
             <artifactId>gt-render</artifactId>
         </dependency>
         <dependency>

--- a/geomesa-gs-wfs/pom.xml
+++ b/geomesa-gs-wfs/pom.xml
@@ -37,11 +37,6 @@
         <!-- provided dependencies -->
         <dependency>
             <groupId>org.geotools</groupId>
-            <artifactId>gt-data</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
             <artifactId>gt-process</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     </modules>
 
     <properties>
-        <geomesa.version>2.3.0</geomesa.version>
+        <geomesa.version>2.4.0-SNAPSHOT</geomesa.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -72,8 +72,8 @@
         <gs.version>2.15.1</gs.version>
         <gt.version>21.1</gt.version>
         <jts.version>1.16.0</jts.version>
-        <imageio-ext.version>1.1.25</imageio-ext.version>
-        <guava.version>25.1-jre</guava.version>
+        <imageio-ext.version>1.2.1</imageio-ext.version>
+        <guava.version>27.0-jre</guava.version>
         <wicket.version>7.6.0</wicket.version>
 
         <!-- This is the spring version in geoserver 2.15.1 -->
@@ -158,6 +158,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.1</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>commons-httpclient</groupId>
                 <artifactId>commons-httpclient</artifactId>
                 <version>3.1</version>
@@ -166,13 +172,13 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.1</version>
+                <version>2.6</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
+                <version>2.5</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,16 +69,16 @@
         <scala.version>2.11.7</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
 
-        <gs.version>2.14.0</gs.version>
-        <gt.version>20.0</gt.version>
+        <gs.version>2.15.1</gs.version>
+        <gt.version>21.1</gt.version>
         <jts.version>1.16.0</jts.version>
         <imageio-ext.version>1.1.25</imageio-ext.version>
         <guava.version>25.1-jre</guava.version>
         <wicket.version>7.6.0</wicket.version>
 
-        <!-- This is the spring version in geoserver 2.12 -->
-        <spring.version>4.3.18.RELEASE</spring.version>
-        <spring.security.version>4.2.7.RELEASE</spring.security.version>
+        <!-- This is the spring version in geoserver 2.15.1 -->
+        <spring.version>5.1.1.RELEASE</spring.version>
+        <spring.security.version>5.1.1.RELEASE</spring.security.version>
 
         <!-- logging properties - we expect logging jars to be provided -->
         <!-- 1.7.x is for hadoop 2 and accumulo 1.5.x -->
@@ -189,12 +189,6 @@
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
-                <artifactId>gt-api</artifactId>
-                <version>${gt.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.geotools</groupId>
                 <artifactId>gt-cql</artifactId>
                 <version>${gt.version}</version>
                 <scope>provided</scope>
@@ -250,12 +244,6 @@
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-coverage</artifactId>
-                <version>${gt.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.geotools</groupId>
-                <artifactId>gt-data</artifactId>
                 <version>${gt.version}</version>
                 <scope>provided</scope>
             </dependency>


### PR DESCRIPTION
In addition to upgrading the GeoServer and GeoTools versions, Spring and Spring security versions were updated to match the versions used in GeoServer 2.15.1.

Note that this PR is dependent on its corresponding PR to core GeoMesa and should not be merged until the GeoMesa PR is merged:

https://github.com/locationtech/geomesa/pull/2271

Signed-off-by: Josh Fix <josh@federal.planet.com>