### PR TITLE
GEOMESA-3409: Arrow: axis order request parameter

### DIFF
--- a/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
+++ b/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
@@ -23,7 +23,6 @@ import org.locationtech.geomesa.arrow.io.FormatVersion
 import org.locationtech.geomesa.arrow.vector.SimpleFeatureVector.SimpleFeatureEncoding
 import org.locationtech.geomesa.index.conf.QueryHints._
 import org.locationtech.geomesa.process.transform.ArrowConversionProcess.ArrowVisitor
-import org.locationtech.geomesa.utils.bin.AxisOrder
 import org.locationtech.geomesa.utils.collection.CloseableIterator
 import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.io.WithClose
@@ -39,7 +38,7 @@ import scala.collection.JavaConverters._
   *   format_options=includeFids:<Boolean>;proxyFids:<Boolean>;dictionaryFields:<field_to_encode>,<field_to_encode>;
   *     useCachedDictionaries:<Boolean>;sortField:<sort_field>;sortReverse:<Boolean>;
   *     batchSize:<Integer>;doublePass:<Boolean>;formatVersion:<String>;
-  *     flattenStruct:<Boolean>;axisOrder:<LatLon||LonLat>;
+  *     flattenStruct:<Boolean>;flipAxisOrder:<Boolean>;
   *
   * @param geoServer geoserver
   */
@@ -147,11 +146,8 @@ class ArrowOutputFormat(geoServer: GeoServer)
     Option(options.get(Fields.FlattenStruct)).foreach { option =>
       hints.put(ARROW_FLATTEN_STRUCT, java.lang.Boolean.valueOf(option.toString))
     }
-    Option(options.get(Fields.AxisOrder)).foreach { option =>
-      hints.put(FLIP_AXIS_ORDER, AxisOrder.withName(option.toString) match {
-        case AxisOrder.LonLat => true
-        case _ => false
-      })
+    Option(options.get(Fields.FlipAxisOrder)).foreach { option =>
+      hints.put(FLIP_AXIS_ORDER, java.lang.Boolean.valueOf(option.toString))
     }
   }
 }
@@ -172,6 +168,6 @@ object ArrowOutputFormat extends LazyLogging {
     val BatchSize             = "BATCHSIZE"
     val ProcessDeltas         = "PROCESSDELTAS"
     val FlattenStruct         = "FLATTENSTRUCT"
-    val AxisOrder             = "AXISORDER"
+    val FlipAxisOrder         = "FLIPAXISORDER"
   }
 }

--- a/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
+++ b/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
@@ -15,9 +15,9 @@ import org.geoserver.ows.Response
 import org.geoserver.platform.Operation
 import org.geoserver.wfs.WFSGetFeatureOutputFormat
 import org.geoserver.wfs.request.{FeatureCollectionResponse, GetFeatureRequest}
-import org.geotools.api.feature.simple.SimpleFeatureType
 import org.geotools.api.filter.sort.SortOrder
 import org.geotools.data.simple.SimpleFeatureCollection
+import org.geotools.referencing.CRS.AxisOrder
 import org.geotools.util.factory.Hints
 import org.locationtech.geomesa.arrow.{ArrowEncodedSft, ArrowProperties}
 import org.locationtech.geomesa.arrow.io.FormatVersion
@@ -38,7 +38,8 @@ import scala.collection.JavaConverters._
   * Optional flags:
   *   format_options=includeFids:<Boolean>;proxyFids:<Boolean>;dictionaryFields:<field_to_encode>,<field_to_encode>;
   *     useCachedDictionaries:<Boolean>;sortField:<sort_field>;sortReverse:<Boolean>;
-  *     batchSize:<Integer>;doublePass:<Boolean>;formatVersion:<String>;flattenStruct:<Boolean>;
+  *     batchSize:<Integer>;doublePass:<Boolean>;formatVersion:<String>;
+  *     flattenStruct:<Boolean>;axisOrder:<NORTH_EAST||EAST_NORTH>;
   *
   * @param geoServer geoserver
   */
@@ -71,7 +72,8 @@ class ArrowOutputFormat(geoServer: GeoServer)
         i += 1
         val sfc = fc.asInstanceOf[SimpleFeatureCollection]
         WithClose(CloseableIterator(sfc.features())) { iter =>
-          val aggregated = SimpleFeatureTypes.compare(sfc.getSchema, ArrowEncodedSft) match {
+          val featureType = sfc.getSchema
+          val aggregated = SimpleFeatureTypes.compare(featureType, ArrowEncodedSft) match {
             case 0 | 1 => true
             case _ => false
           }
@@ -85,7 +87,7 @@ class ArrowOutputFormat(geoServer: GeoServer)
             val hints = new Hints()
             populateFormatOptions(request, hints)
 
-            val encoding = SimpleFeatureEncoding.min(hints.isArrowIncludeFid, hints.isArrowProxyFid)
+            val encoding = SimpleFeatureEncoding.min(hints.isArrowIncludeFid, hints.isArrowProxyFid, hints.getAxisOrder)
             val dictionaries = hints.getArrowDictionaryFields
             val version = hints.getArrowFormatVersion.getOrElse(FormatVersion.ArrowFormatVersion.get)
             val sortField = hints.getArrowSort.map(_._1)
@@ -103,8 +105,7 @@ class ArrowOutputFormat(geoServer: GeoServer)
               }
             }
 
-            val visitor =
-              new ArrowVisitor(fc.getSchema.asInstanceOf[SimpleFeatureType], encoding, version,
+            val visitor = new ArrowVisitor(featureType, encoding, version,
                 dictionaries, sortField, sortReverse, preSorted.getOrElse(false), batchSize, flattenStruct)
 
             iter.foreach(visitor.visit)
@@ -146,6 +147,9 @@ class ArrowOutputFormat(geoServer: GeoServer)
     Option(options.get(Fields.FlattenStruct)).foreach { option =>
       hints.put(ARROW_FLATTEN_STRUCT, java.lang.Boolean.valueOf(option.toString))
     }
+    Option(options.get(Fields.AxisOrder)).foreach { option =>
+      hints.put(AXIS_ORDER, AxisOrder.valueOf(option.toString))
+    }
   }
 }
 
@@ -165,5 +169,6 @@ object ArrowOutputFormat extends LazyLogging {
     val BatchSize             = "BATCHSIZE"
     val ProcessDeltas         = "PROCESSDELTAS"
     val FlattenStruct         = "FLATTENSTRUCT"
+    val AxisOrder             = "AXISORDER"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     </modules>
 
     <properties>
-        <geomesa.version>5.1.0</geomesa.version>
+        <geomesa.version>5.2.0-SNAPSHOT</geomesa.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     </modules>
 
     <properties>
-        <geomesa.version>5.2.0-SNAPSHOT</geomesa.version>
+        <geomesa.version>5.2.0</geomesa.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     </modules>
 
     <properties>
-        <geomesa.version>5.2.0</geomesa.version>
+        <geomesa.version>5.2.0-SNAPSHOT</geomesa.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
[GEOMESA-3409](https://geomesa.atlassian.net/browse/GEOMESA-3409): Geomesa currently defaults to always reading and writing Arrow encoding as NORTH_EAST axis order.

With the new axis order request parameter allow the user to request the encoding to be explicitly specified per request.

Axis Order parameter supported values:

- `NORTH_EAST` translates to: North = Latitude = Y Axis, East = Longitude = X Axis
- `EAST_NORTH` translates to: East = Longitude = X Axis, North = Latitude = Y Axis

The request parameter is optional and if not specified axis order defaults to the existing behavior which is NORTH_EAST.

Notes:

- This is a draft PR and is currently only implemented for Point geometries (additional Geometries to follow into the `geomesa` repo PR);
- This has been manually tested and working on the 4.0.4 branch and ported to the main line, automated tests to be added