### PR TITLE
GEOMESA-3476: Kafka: arrow: flattenStruct request parameter

### DIFF
--- a/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
+++ b/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
@@ -90,7 +90,9 @@ class ArrowOutputFormat(geoServer: GeoServer)
               throw new NotImplementedError(s"${getClass.getTypeName}: incompatible request parameters: 'flattenStruct' and 'processDeltas'")
             }
             WithClose(SimpleFeatureArrowFileReader.caching(featureSequenceInputStream(iter))) { reader =>
-              arrowVisitor(request, hints, i, bos, reader.features(), reader.sft)
+              WithClose(reader.features()) { features =>
+                arrowVisitor(request, hints, i, bos, features, reader.sft)
+              }
             }
           } else {
             // with distributed processing, encodings have already been computed in the servers

--- a/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
+++ b/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
@@ -29,7 +29,6 @@ import org.locationtech.geomesa.utils.geotools.SimpleFeatureTypes
 import org.locationtech.geomesa.utils.io.WithClose
 
 import java.io.{BufferedOutputStream, ByteArrayInputStream, OutputStream, SequenceInputStream}
-import java.util
 import scala.collection.JavaConverters._
 
 /**
@@ -168,11 +167,7 @@ class ArrowOutputFormat(geoServer: GeoServer)
     feature.getAttribute(0).asInstanceOf[Array[Byte]]
 
   private def featureSequenceInputStream(iter: CloseableIterator[SimpleFeature]): SequenceInputStream = {
-    val streamEnumeration = new util.Enumeration[ByteArrayInputStream] {
-      private val iterator = iter.map { feature => new ByteArrayInputStream(toByteArray(feature)) }
-      override def hasMoreElements: Boolean = iterator.hasNext
-      override def nextElement(): ByteArrayInputStream = iterator.next()
-    }
+    val streamEnumeration = iter.map(feature => new ByteArrayInputStream(toByteArray(feature))).asJavaEnumeration
     new SequenceInputStream(streamEnumeration)
   }
 }

--- a/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
+++ b/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
@@ -167,7 +167,7 @@ class ArrowOutputFormat(geoServer: GeoServer)
     feature.getAttribute(0).asInstanceOf[Array[Byte]]
 
   private def featureSequenceInputStream(iter: CloseableIterator[SimpleFeature]): SequenceInputStream = {
-    val streamEnumeration = iter.map(feature => new ByteArrayInputStream(toByteArray(feature))).asJavaEnumeration
+    val streamEnumeration = iter.map(toByteArray).map(new ByteArrayInputStream(_)).asJavaEnumeration
     new SequenceInputStream(streamEnumeration)
   }
 }

--- a/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
+++ b/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
@@ -80,7 +80,6 @@ class ArrowOutputFormat(geoServer: GeoServer)
             case 0 | 1 => true
             case _ => false
           }
-
           hints match {
             case _ if !aggregated =>
               // for non-encoded fs we do the encoding here
@@ -168,7 +167,7 @@ class ArrowOutputFormat(geoServer: GeoServer)
   }
 
   private def featureSequenceInputStream(iter: CloseableIterator[SimpleFeature]): SequenceInputStream = {
-    val streamEnumeration: util.Enumeration[ByteArrayInputStream] = new util.Enumeration[ByteArrayInputStream] {
+    val streamEnumeration = new util.Enumeration[ByteArrayInputStream] {
       private val iterator = iter.map { feature =>
         val bytes = feature.getAttribute(0).asInstanceOf[Array[Byte]]
         new ByteArrayInputStream(bytes)
@@ -176,7 +175,6 @@ class ArrowOutputFormat(geoServer: GeoServer)
       override def hasMoreElements: Boolean = iterator.hasNext
       override def nextElement(): ByteArrayInputStream = iterator.next()
     }
-    // SequenceInputStream concatenating Feature byte arrays
     new SequenceInputStream(streamEnumeration) {
       override def close(): Unit = {
         super.close()

--- a/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
+++ b/geomesa-gs-wfs/src/main/scala/org/geomesa/gs/wfs/output/ArrowOutputFormat.scala
@@ -79,7 +79,7 @@ class ArrowOutputFormat(geoServer: GeoServer)
             case 0 | 1 => true
             case _ => false
           }
-          if (hints.isArrowProcessDeltas) {
+          if (!hints.isArrowProcessDeltas) {
             iter.map(_.getAttribute(0).asInstanceOf[Array[Byte]]).foreach(bos.write)
           } else if (aggregated) {
             // with distributed processing, encodings have already been computed in the servers


### PR DESCRIPTION
[GEOMESA-3476](https://geomesa.atlassian.net/browse/GEOMESA-3476)

Honor the `flattenStruct` request parameter when using Kafka data store to output Arrow formatted responses by removing the top level SFT type name as the root